### PR TITLE
fix error in Node deserialization if EID list is empty

### DIFF
--- a/dtn7-esp/include/Misc/helpers.h
+++ b/dtn7-esp/include/Misc/helpers.h
@@ -12,7 +12,7 @@
  */
 
 /// @brief reads an std::string from a CborValue containing a CBOR Text string. The given CborValue is advanced to the next element after the String
-/// @param value the CborValue to read string from. Will be advanced to next element after the string
+/// @param value the CborValue to read string from. Will NOT be advanced to next element after the string, as this leads to decoding errors if the next element is a CBOR primitive type
 /// @return the String Stored in the CborValue, or a string containing "error" if no string was stored
 inline std::string stringFromCbor(CborValue* value) {
     // check if passed value is a CBOR text string
@@ -24,9 +24,6 @@ inline std::string stringFromCbor(CborValue* value) {
 
         // copy string into char array
         cbor_value_copy_text_string(value, idChars, &idLength, value);
-
-        // advance value to next element
-        cbor_value_advance(value);
 
         // return read string
         return std::string(idChars, idLength);

--- a/dtn7-esp/src/Data.cpp
+++ b/dtn7-esp/src/Data.cpp
@@ -1,5 +1,6 @@
 #include "Data.hpp"
 #include "cbor.h"
+#include "esp_log.h"
 #include "helpers.h"
 
 BundleInfo::BundleInfo(std::vector<uint8_t> serialized) {
@@ -146,7 +147,18 @@ Node::Node(std::vector<uint8_t> serialized) {
 
         // decode the individual elements using custom functions
         identifier = stringFromCbor(&ArrayValue);
-        Eids = decodeEidArray(&ArrayValue);
+        size_t arraySize=0;
+
+        //if the EID array is empty, just advance the value pointer
+        cbor_value_get_array_length(&ArrayValue, &arraySize); 
+        if(arraySize==0) {
+            cbor_value_advance(&ArrayValue);
+        }
+        else { 
+            Eids=decodeEidArray(&ArrayValue);
+            cbor_value_advance(&ArrayValue);
+        }
+        
         URI = stringFromCbor(&ArrayValue);
 
         // read the simple parameters using simple get value methods of the cbor libary


### PR DESCRIPTION
In special cases it may be possible that a node with an empty array of EIDs is serialized, in this case the current decoding implementation leads to errors.
To fix this the array of EIDs is handled differently during decoding if it is empty.