### PR TITLE
Fixes automatic doxygen generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   doxygen:
     runs-on: ubuntu-latest
@@ -25,6 +28,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: doxygen/html


### PR DESCRIPTION
The issue was missing write permission, by setting this in the configuration the need for an access token could be bypassed.